### PR TITLE
let test_server run forever

### DIFF
--- a/valve_sim/valve_plc.py
+++ b/valve_sim/valve_plc.py
@@ -194,3 +194,4 @@ for var in valve.get_plc_vars():
 
 test_server = AdsTestServer(handler=handler, logging=True)
 test_server.start()
+test_server.join()


### PR DESCRIPTION
Call `test_server.join()` (blocking) at the end of the script to let the service run forever.